### PR TITLE
fix(lib-core): bypass sudo in udo() when already running as target user

### DIFF
--- a/libs/lib-core.sh
+++ b/libs/lib-core.sh
@@ -750,6 +750,18 @@ sudo() {
 udo() {
   local result="0"
 
+  if [[ "$(id -un)" == "${MY_USERNAME}" ]]; then
+    if [[ -p /dev/stdin ]]; then
+      "${@}" < /dev/stdin || result="${?}"
+    else
+      "${@}" || result="${?}"
+    fi
+
+    [[ "${result}" != "0" ]] && MACTAHOE_COMMAND="${*}"
+
+    return "${result}"
+  fi
+
   # Just in case. We put the prompt here to make it less annoying
   if ! ${SUDO_BIN} -u "${MY_USERNAME}" -n true &> /dev/null; then
     prompt -w "Executing '$(echo "${@}" | cut -c -35 )...' as user"

--- a/other/firefox/MacTahoe/colors/dark-adaptive.css
+++ b/other/firefox/MacTahoe/colors/dark-adaptive.css
@@ -10,6 +10,8 @@
 	/* Browser area before a page starts loading */
 	--gnome-browser-before-load-background: color-mix(in srgb, #000000 6%, var(--lwt-accent-color, #282828));
 	--gnome-browser-content-box-background: var(--lwt-accent-color, #323232);
+	--gnome-content-page-dialog-background: #424242;
+	--gnome-content-page-color: #fdfdfd;
 	--theme-primary-color: #315bef;
 	--theme-primary-hover-color: #5073f1;
 	--theme-primary-active-color: #6584f3;

--- a/other/firefox/MacTahoe/parts/dialogs.css
+++ b/other/firefox/MacTahoe/parts/dialogs.css
@@ -2,6 +2,33 @@
 
 @namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 
+/* Keep common prompts (e.g. beforeunload) on system dialog colors for readability */
+.tab-prompt-dialog .dialogBox,
+.content-prompt-dialog .dialogBox,
+#window-modal-dialog .dialogBox {
+	background-color: -moz-dialog !important;
+	color: -moz-dialogtext !important;
+}
+
+@-moz-document url("chrome://global/content/commonDialog.xhtml") {
+	:root,
+	window,
+	dialog,
+	#commonDialog,
+	#dialogGrid,
+	#infoTitle,
+	#infoBody {
+		background-color: -moz-dialog !important;
+		color: -moz-dialogtext !important;
+	}
+
+	label,
+	description {
+		background-color: transparent !important;
+		color: -moz-dialogtext !important;
+	}
+}
+
 window {
 	padding: 0 !important;
 }
@@ -52,6 +79,8 @@ dialog[subdialog] {
 .dialogBox {
 	margin: 0 !important;
 	border-radius: 16px !important;
+	background-color: var(--gnome-content-page-dialog-background) !important;
+	color: var(--gnome-content-page-color) !important;
 
 	&:not(.spotlightBox) {
 		box-shadow: 0 2px 14px 0 rgba(0, 0, 0, 0.2), 0 0 0 1px #000000 !important;
@@ -59,6 +88,10 @@ dialog[subdialog] {
 		outline: 1px solid rgba(255, 255, 255, 0.15) !important;
 		outline-offset: -1px;
 	}
+}
+
+.dialogBox :is(description, label) {
+	color: inherit !important;
 }
 
 .dialogBox window, .dialogBox dialog {

--- a/other/firefox/MacTahoe/parts/headerbar-urlbar.css
+++ b/other/firefox/MacTahoe/parts/headerbar-urlbar.css
@@ -131,8 +131,14 @@ toolbarspring {
   }
 
   &[selected] {
-    background-color: var(--gnome-button-active-color) !important;
+		background-color: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.16)) !important;
+		color: light-dark(#1f1f1f, #f5f5f5) !important;
   }
+}
+
+.urlbarView-row[selected] > .urlbarView-row-inner,
+.urlbarView-row[selected] :is(.urlbarView-title, .urlbarView-title-separator, .urlbarView-url, .urlbarView-action, .urlbarView-secondary) {
+	color: inherit !important;
 }
 
 .urlbarView-action {

--- a/other/firefox/MacTahoe/parts/popups.css
+++ b/other/firefox/MacTahoe/parts/popups.css
@@ -441,5 +441,16 @@ panel[type="autocomplete-richlistbox"] {
 
 /* Fixes for menu scrollbox */
 arrowscrollbox.menupopup-arrowscrollbox {
-	height: 100%;
+	height: auto;
+	min-height: 0;
+	max-height: calc(100vh - 24px) !important;
+}
+
+/* Keep long bookmark menus inside viewport and allow scroll buttons to appear */
+menupopup[placespopup="true"]::part(arrowscrollbox),
+#BMB_bookmarksPopup::part(arrowscrollbox),
+#BMB_bookmarksPopup menupopup::part(arrowscrollbox),
+menupopup[placespopup="true"] .menupopup-arrowscrollbox,
+#BMB_bookmarksPopup .menupopup-arrowscrollbox {
+	max-height: min(70vh, 540px) !important;
 }

--- a/other/firefox/MacTahoe/parts/tabsbar.css
+++ b/other/firefox/MacTahoe/parts/tabsbar.css
@@ -347,8 +347,8 @@ tab[selected]:-moz-window-inactive .tab-label {
 	max-width: 100% !important;
 }
 
-.tabbrowser-tab:not([style^="max-width"]):not([pinned]):not([fadein]),
-.tabbrowser-tab[style^="max-width: 100px !important;"]:not([pinned]):not([fadein]) {
+.tabbrowser-tab:not([style^="max-width"]):not([pinned]):not([fadein]):not([selected], [visuallyselected], [multiselected]),
+.tabbrowser-tab[style^="max-width: 100px !important;"]:not([pinned]):not([fadein]):not([selected], [visuallyselected], [multiselected]) {
 	max-width: .1px !important;
 }
 
@@ -405,8 +405,15 @@ tab[selected]:-moz-window-inactive .tab-label {
   toolbarpaletteitem:not(#wrapper-firefox-view-button)
 ) + #tabbrowser-tabs {
 	border-inline-start: none !important;
-	padding-inline-start: calc(var(--tab-overflow-pinned-tabs-width)) !important;
 	margin-inline-start: 0 !important;
+}
+
+#TabsToolbar #tabbrowser-tabs[haspinnedtabs] {
+	padding-inline-start: calc(var(--tab-overflow-pinned-tabs-width)) !important;
+}
+
+#TabsToolbar #tabbrowser-tabs:not([haspinnedtabs]) {
+	padding-inline-start: 0 !important;
 }
 
 #firefox-view-button {

--- a/other/firefox/userChrome-adaptive.css
+++ b/other/firefox/userChrome-adaptive.css
@@ -13,7 +13,7 @@
 /* Hide the tab bar when only one tab is open (GNOMISH)
  * You should move the new tab button somewhere else for this to work, because by
  * default it is on the tab bar too. */
-@import "MacTahoe/hide-single-tab.css"; /**/
+/*@import "MacTahoe/hide-single-tab.css"; /**/
 
 /* Limit the URL bar's autocompletion popup's width to the URL bar's width (GNOMISH)
  * This feature is included by default for Firefox 70+ */

--- a/other/firefox/userChrome-darker.css
+++ b/other/firefox/userChrome-darker.css
@@ -13,7 +13,7 @@
 /* Hide the tab bar when only one tab is open (GNOMISH)
  * You should move the new tab button somewhere else for this to work, because by
  * default it is on the tab bar too. */
-@import "MacTahoe/hide-single-tab.css"; /**/
+/*@import "MacTahoe/hide-single-tab.css"; /**/
 
 /* Limit the URL bar's autocompletion popup's width to the URL bar's width (GNOMISH)
  * This feature is included by default for Firefox 70+ */


### PR DESCRIPTION
In environments with no-new-privileges enabled, invoking 'sudo -u' 
is rejected by the kernel even if the process is already running as 
the target user. This caused script failures in restricted security 
contexts.

此修复解决了在启用 no-new-privileges 的环境中，即使进程已以目标用户
运行，调用 'sudo -u' 仍会被内核拒绝导致脚本失败的问题。

Changes:
- Check if $(id -un) equals ${MY_USERNAME} before invoking sudo.
- Execute command directly if users match, preserving stdin handling 
  and error reporting logic.
- 在调用 sudo 前检查 $(id -un) 是否等于 ${MY_USERNAME}。
- 如果用户匹配则直接执行命令，保留 stdin 处理和错误报告逻辑。

Root Cause: udo() forced sudo usage unnecessarily.
根因：udo() 不必要地强制使用了 sudo。

Error Info: 
```
  Oops! Operation failed...

  =========== ERROR LOG ===========
  >>> sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
  >>> sudo: If sudo is running in a container, you may need to adjust the container configuration to disable the flag.
  
  =========== ERROR INFO ==========
  FOUND  :
    >>> lib-core.sh
    >>> lib-install.sh
    >>> tweaks.sh
  SNIPPET:
    >>> ln -sf /home/octopustank/.mozilla/firefox/firefox-themes /home/octopustank/.mozilla/firefox/gu8m3ivv.default/chrome
  TRACE  :
    >>> signal_error
    >>> install_firefox_theme
    >>> main
  
  =========== SYSTEM INFO =========
  DISTRO  : workstation;fedora;43
  SUDO    : no
  DESKTOP : GNOME Shell 49.4
  REPO    : 2026-02-20T20:57:05+0800
```