### PR TITLE
fix: Add styles for trust icon container in headerbar

### DIFF
--- a/other/firefox/MacTahoe/parts/headerbar-urlbar.css
+++ b/other/firefox/MacTahoe/parts/headerbar-urlbar.css
@@ -218,12 +218,27 @@ toolbarspring {
 .search-go-button,
 .identity-box-button,
 #notification-popup-box,
-#tracking-protection-icon-container {
+#tracking-protection-icon-container,
+#trust-icon-container {
 	min-width: 30px !important;
 	min-height: 30px !important;
 	margin: 3px 3px 3px 0 !important;
 	padding: 7px !important;
 	border-radius: 999px !important;
+}
+
+#trust-icon-container {
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
+}
+
+#urlbar:not([pageproxystate="valid"]) #trust-icon-container {
+	display: none !important;
+}
+
+#trust-icon-container:not(.secure):not(.insecure) {
+	display: none !important;
 }
 
 .urlbar-page-action,


### PR DESCRIPTION
Firefox 149 removed the identity-icon and replaced it with trust-icon, leading to misalignment issues with the theme. This is a quick hack to fix that bug.

Before: 
<img width="1077" height="58" alt="image" src="https://github.com/user-attachments/assets/aa3dd3e1-7058-403b-be3a-61416a8029c6" />

After: 
<img width="1077" height="58" alt="image" src="https://github.com/user-attachments/assets/c9915af4-3373-4951-b7b1-6293b2010b46" />
