### PR TITLE
(Firefox Theme, CSS) Fix urlbar-go-button and fullscreen titlebar restore button size issue

### DIFF
--- a/other/firefox/MacTahoe/parts/csd.css
+++ b/other/firefox/MacTahoe/parts/csd.css
@@ -94,9 +94,9 @@
 
 	#nav-bar .titlebar-button,
 	#titlebar .titlebar-button {
-		height: 24px;
-		width: 24px;
-		margin: 12px 4px !important;
+		height: 20px;
+		width: 20px;
+		margin-right: 12px !important;
 		padding: 0 !important;
 	}
 

--- a/other/firefox/MacTahoe/parts/headerbar-urlbar.css
+++ b/other/firefox/MacTahoe/parts/headerbar-urlbar.css
@@ -251,13 +251,21 @@ toolbarspring {
 
 .urlbar-page-action,
 .urlbar-revert-button,
-#star-button-box,
-#urlbar-go-button,
-.urlbar-go-button {
+#star-button-box, {
 	min-width: 30px !important;
 	min-height: 30px !important;
 	margin: 3px 0 3px 3px !important;
 	padding: 7px !important;
+	border-radius: 999px !important;
+}
+
+/*This had to be moved away from the star-button due to size issues*/
+#urlbar-go-button,
+.urlbar-go-button {
+	min-width: 16px !important;
+	min-height: 16px !important;
+	margin: 3px 0 3px 3px !important;
+	padding: 1px !important;
 	border-radius: 999px !important;
 }
 


### PR DESCRIPTION
The urlbar-go-button was bigger than it should be, and went out of the urlbar so I went into the code and noticed it shared it's width and other size variables with the star, and since they were connected, the urlbar-go-button became unusually larger, if I didn't separate it from the star, it would instead mess up the star's alignment, so I separated it and hopefully it should be fixed.

Edit 1: Added in a change to adjust the titlebar restore button's size to be a bit less big, and a bit more aligned.