### PR TITLE
Fix release_info() writing first line to cwd instead of RELEASE_DIR

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -42,7 +42,7 @@ compress() {
 release_info() {
 rm -rf ${RELEASE_DIR}/release-info.txt
 
-echo >> release-info.txt
+echo >> "${RELEASE_DIR}/release-info.txt"
 echo "VERSION: (GNOME-SHELL) ${RELEASE_VERSION}" >> ${RELEASE_DIR}/release-info.txt
 echo >> ${RELEASE_DIR}/release-info.txt
 echo "RELEASE TIME: $(date)" >> ${RELEASE_DIR}/release-info.txt


### PR DESCRIPTION
## Summary

Fixes a path inconsistency in the `release_info()` function of `make-release.sh`. The initial blank line was written to `release-info.txt` in the current working directory instead of `${RELEASE_DIR}/release-info.txt`, where all other lines are written.

## The bug

```bash
# Line 45 (before fix) — writes to cwd
echo >> release-info.txt

# Lines 46-56 — writes to the correct path
echo "VERSION: ..." >> ${RELEASE_DIR}/release-info.txt
```

This caused two issues:
1. A stray empty `release-info.txt` file was created in whatever directory the script was run from
2. The actual release info file in `release/` was missing its leading blank line

## The fix

Aligns line 45 with the rest of the function:

```diff
- echo >> release-info.txt
+ echo >> "${RELEASE_DIR}/release-info.txt"
```

## Testing

```bash
# Before fix — observe stray file in cwd
ls -la release-info.txt  # exists (bug)

# After fix — only the correct file exists
ls -la release/release-info.txt  # correct
ls -la release-info.txt          # No such file
```