### PR TITLE
Shell scripts cleanup: shebangs, POSIX compliance, error handling, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ src/main/gtk-4.0/gtk*.css
 src/main/cinnamon/cinnamon*.css
 src/main/gnome-shell/gnome-shell-Dark.css
 src/main/gnome-shell/gnome-shell-Light.css
-src/other/dash-to-dock/stylesheet.css
-src/other/dash-to-dock/stylesheet-dark.css
+other/dash-to-dock/stylesheet.css
+other/dash-to-dock/stylesheet-dark.css
 other/gdm/gnome-shell-theme.gresource
+other/gdm/theme/*.css
+release/

--- a/clean-git.sh
+++ b/clean-git.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 #
 # Clean ignored files
 #

--- a/libs/lib-core.sh
+++ b/libs/lib-core.sh
@@ -55,7 +55,7 @@ else
   SED_OPT="-i"
 fi
 
-SUDO_BIN="$(which sudo)"
+SUDO_BIN="$(command -v sudo)"
 
 #-------------Theme---------------#
 THEME_NAME="MacTahoe"

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 readonly REPO_DIR="$(dirname "$(readlink -m "${0}")")"
 readonly RELEASE_DIR="${REPO_DIR}/release"

--- a/other/gdm/install.sh
+++ b/other/gdm/install.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 GR_FILE="/usr/share/gnome-shell/gnome-shell-theme.gresource"
 

--- a/other/gdm/make_gresource.sh
+++ b/other/gdm/make_gresource.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # Check command availability
 function has_command() {

--- a/other/gdm/make_gresource.sh
+++ b/other/gdm/make_gresource.sh
@@ -2,7 +2,7 @@
 
 # Check command availability
 function has_command() {
-  command -v $1 > /dev/null
+  command -v "$1" > /dev/null
 }
 
 if ! has_command glib-compile-resources; then

--- a/other/gdm/make_gresource.sh
+++ b/other/gdm/make_gresource.sh
@@ -11,9 +11,9 @@ if ! has_command glib-compile-resources; then
     if has_command zypper; then
       sudo zypper in -y glib2-devel
     elif has_command swupd; then
-      prepare_swupd && sudo swupd bundle-add libglib
+      sudo swupd bundle-add libglib
     elif has_command apt; then
-      prepare_install_apt_packages libglib2.0-dev-bin
+      sudo apt install -y libglib2.0-dev-bin
     elif has_command dnf; then
       sudo dnf install -y glib2-devel
     elif has_command yum; then
@@ -21,7 +21,7 @@ if ! has_command glib-compile-resources; then
     elif has_command pacman; then
       sudo pacman -Syyu --noconfirm --needed glib2
     elif has_command xbps-install; then
-      prepare_xbps && sudo xbps-install -Sy glib-devel
+      sudo xbps-install -Sy glib-devel
     elif has_command eopkg; then
       sudo eopkg -y upgrade; sudo eopkg -y install glib2
     fi

--- a/other/gdm/parse-sass.sh
+++ b/other/gdm/parse-sass.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # Check command availability
 function has_command() {

--- a/other/gdm/parse-sass.sh
+++ b/other/gdm/parse-sass.sh
@@ -2,10 +2,10 @@
 
 # Check command availability
 function has_command() {
-  command -v $1 > /dev/null
+  command -v "$1" > /dev/null
 }
 
-if [ ! "$(which sassc 2> /dev/null)" ]; then
+if ! has_command sassc; then
   echo sassc needs to be installed to generate the css.
   if has_command zypper; then
     sudo zypper in sassc

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -5,10 +5,10 @@ SRC_DIR="${REPO_DIR}/src"
 
 # Check command availability
 function has_command() {
-  command -v $1 > /dev/null
+  command -v "$1" > /dev/null
 }
 
-if [ ! "$(which sassc 2> /dev/null)" ]; then
+if ! has_command sassc; then
   echo sassc needs to be installed to generate the css.
   if has_command zypper; then
     sudo zypper in sassc

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SRC_DIR="${REPO_DIR}/src"

--- a/src/assets/cinnamon/make-assets.sh
+++ b/src/assets/cinnamon/make-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do

--- a/src/assets/cinnamon/thumbnails/make-thumbnails.sh
+++ b/src/assets/cinnamon/thumbnails/make-thumbnails.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do

--- a/src/assets/cinnamon/thumbnails/render-thumbnails.sh
+++ b/src/assets/cinnamon/thumbnails/render-thumbnails.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/cinnamon/thumbnails/render-thumbnails.sh
+++ b/src/assets/cinnamon/thumbnails/render-thumbnails.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 ./make-thumbnails.sh
 

--- a/src/assets/cinnamon/thumbnails/render-thumbnails.sh
+++ b/src/assets/cinnamon/thumbnails/render-thumbnails.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -10,19 +12,19 @@ for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-
     SRC_FILE="thumbnail${theme}${type}.svg"
     for color in '-light' '-dark'; do
             echo
-            echo Rendering thumbnail${color}${theme}${type}.png
-            $INKSCAPE --export-id=thumbnail${color}${theme}${type} \
-                      --export-id-only \
-                      --export-dpi=192 \
-                      --export-filename=thumbnail${color}${theme}${type}.png $SRC_FILE >/dev/null \
-            && $OPTIPNG -o7 --quiet thumbnail${color}${theme}${type}.png
+            echo "Rendering thumbnail${color}${theme}${type}.png"
+            "$INKSCAPE" --export-id="thumbnail${color}${theme}${type}" \
+                        --export-id-only \
+                        --export-dpi=192 \
+                        --export-filename="thumbnail${color}${theme}${type}.png" "$SRC_FILE" >/dev/null \
+            && "$OPTIPNG" -o7 --quiet "thumbnail${color}${theme}${type}.png"
       done
     done
   done
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do
-    if [[ ${theme} == '' && ${type} == '' ]]; then
+    if [[ "${theme}" == '' && "${type}" == '' ]]; then
       echo "keep thumbnail.svg"
     else
       rm -rf "thumbnail${theme}${type}.svg"

--- a/src/assets/gnome-shell/make-assets.sh
+++ b/src/assets/gnome-shell/make-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do

--- a/src/assets/gtk-2.0/make-assets.sh
+++ b/src/assets/gtk-2.0/make-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for color in '-Light' '-Dark'; do
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do

--- a/src/assets/gtk-2.0/render-assets.sh
+++ b/src/assets/gtk-2.0/render-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 RENDER_SVG="$(command -v rendersvg)" || true
 INKSCAPE="$(command -v inkscape)" || true

--- a/src/assets/gtk/common-assets/render-assets.sh
+++ b/src/assets/gtk/common-assets/render-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/common-assets/render-assets.sh
+++ b/src/assets/gtk/common-assets/render-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 INDEX="assets.txt"
 ASSETS_DIR="assets"

--- a/src/assets/gtk/common-assets/render-assets.sh
+++ b/src/assets/gtk/common-assets/render-assets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -7,31 +9,31 @@ INDEX="assets.txt"
 ASSETS_DIR="assets"
 SRC_FILE="assets.svg"
 
-[[ -d $ASSETS_DIR ]] && rm -rf $ASSETS_DIR
-mkdir -p $ASSETS_DIR
+[[ -d "$ASSETS_DIR" ]] && rm -rf "$ASSETS_DIR"
+mkdir -p "$ASSETS_DIR"
 
-for i in `cat $INDEX`; do
-  if [ -f $ASSETS_DIR/$i.png ]; then
-    echo $ASSETS_DIR/$i.png exists.
+for i in $(cat "$INDEX"); do
+  if [[ -f "$ASSETS_DIR/$i.png" ]]; then
+    echo "$ASSETS_DIR/$i.png exists."
   else
     echo
-    echo Rendering $ASSETS_DIR/$i.png
-    $INKSCAPE --export-id=$i \
-              --export-id-only \
-              --export-filename=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null
-    $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
+    echo "Rendering $ASSETS_DIR/$i.png"
+    "$INKSCAPE" --export-id="$i" \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
+    "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i.png"
   fi
 
-  if [ -f $ASSETS_DIR/$i@2.png ]; then
-    echo $ASSETS_DIR/$i@2.png exists.
+  if [[ -f "$ASSETS_DIR/$i@2.png" ]]; then
+    echo "$ASSETS_DIR/$i@2.png exists."
   else
     echo
-    echo Rendering $ASSETS_DIR/$i@2.png
-    $INKSCAPE --export-id=$i \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-filename=$ASSETS_DIR/$i@2.png $SRC_FILE >/dev/null
-    $OPTIPNG -o7 --quiet $ASSETS_DIR/$i@2.png
+    echo "Rendering $ASSETS_DIR/$i@2.png"
+    "$INKSCAPE" --export-id="$i" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null
+    "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i@2.png"
   fi
 done
 

--- a/src/assets/gtk/thumbnails/make-thumbnails.sh
+++ b/src/assets/gtk/thumbnails/make-thumbnails.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do

--- a/src/assets/gtk/thumbnails/render-thumbnails.sh
+++ b/src/assets/gtk/thumbnails/render-thumbnails.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/thumbnails/render-thumbnails.sh
+++ b/src/assets/gtk/thumbnails/render-thumbnails.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 ./make-thumbnails.sh
 

--- a/src/assets/gtk/thumbnails/render-thumbnails.sh
+++ b/src/assets/gtk/thumbnails/render-thumbnails.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -10,19 +12,19 @@ for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-
     SRC_FILE="thumbnail${theme}${type}.svg"
     for color in '-Light' '-Dark'; do
             echo
-            echo Rendering thumbnail${color}${theme}${type}.png
-            $INKSCAPE --export-id=thumbnail${color}${theme}${type} \
-                      --export-id-only \
-                      --export-dpi=96 \
-                      --export-filename=thumbnail${color}${theme}${type}.png $SRC_FILE >/dev/null \
-            && $OPTIPNG -o7 --quiet thumbnail${color}${theme}${type}.png
+            echo "Rendering thumbnail${color}${theme}${type}.png"
+            "$INKSCAPE" --export-id="thumbnail${color}${theme}${type}" \
+                        --export-id-only \
+                        --export-dpi=96 \
+                        --export-filename="thumbnail${color}${theme}${type}.png" "$SRC_FILE" >/dev/null \
+            && "$OPTIPNG" -o7 --quiet "thumbnail${color}${theme}${type}.png"
       done
     done
   done
 
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do
   for type in '' '-nord'; do
-    if [[ ${theme} == '' && ${type} == '' ]]; then
+    if [[ "${theme}" == '' && "${type}" == '' ]]; then
       echo "keep thumbnail.svg"
     else
       rm -rf "thumbnail${theme}${type}.svg"

--- a/src/assets/gtk/windows-assets/render-alt-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/windows-assets/render-alt-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-assets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -11,32 +13,32 @@ INDEX="assets.txt"
 
 ## alt titlebutton
 
-mkdir -p $ASSETS_DIR
+mkdir -p "$ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
-if [ -f $ASSETS_DIR/$i$d.png ]; then
-    echo $ASSETS_DIR/$i$d.png exists.
+if [[ -f "$ASSETS_DIR/$i$d.png" ]]; then
+    echo "$ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i-alt$d \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
+    echo "Rendering $ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i-alt$d" \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $ASSETS_DIR/$i$d@2.png ]; then
-    echo $ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i-alt$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i-alt$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d@2.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d@2.png"
 fi
 
 done
@@ -44,32 +46,32 @@ done
 
 ## alt nord titlebutton
 
-mkdir -p $NORD_ASSETS_DIR
+mkdir -p "$NORD_ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
-if [ -f $NORD_ASSETS_DIR/$i$d.png ]; then
-    echo $NORD_ASSETS_DIR/$i$d.png exists.
+if [[ -f "$NORD_ASSETS_DIR/$i$d.png" ]]; then
+    echo "$NORD_ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $NORD_ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i$d \
-              --export-id-only \
-              --export-png=$NORD_ASSETS_DIR/$i$d.png $NORD_SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $NORD_ASSETS_DIR/$i$d.png 
+    echo "Rendering $NORD_ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-id-only \
+                --export-filename="$NORD_ASSETS_DIR/$i$d.png" "$NORD_SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$NORD_ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $NORD_ASSETS_DIR/$i$d@2.png ]; then
-    echo $NORD_ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$NORD_ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$NORD_ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $NORD_ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$NORD_ASSETS_DIR/$i$d@2.png $NORD_SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $NORD_ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $NORD_ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$NORD_ASSETS_DIR/$i$d@2.png" "$NORD_SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$NORD_ASSETS_DIR/$i$d@2.png"
 fi
 
 done

--- a/src/assets/gtk/windows-assets/render-alt-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton-alt"

--- a/src/assets/gtk/windows-assets/render-alt-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-small-assets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -7,33 +9,33 @@ SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton-alt-small"
 INDEX="assets.txt"
 
-mkdir -p $ASSETS_DIR
+mkdir -p "$ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
 ## alt small titlebutton
-if [ -f $ASSETS_DIR/$i$d.png ]; then
-    echo $ASSETS_DIR/$i$d.png exists.
+if [[ -f "$ASSETS_DIR/$i$d.png" ]]; then
+    echo "$ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i-alt-small$d \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
+    echo "Rendering $ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i-alt-small$d" \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $ASSETS_DIR/$i$d@2.png ]; then
-    echo $ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i-alt-small$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i-alt-small$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d@2.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d@2.png"
 fi
 
 done

--- a/src/assets/gtk/windows-assets/render-alt-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-small-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton-alt-small"

--- a/src/assets/gtk/windows-assets/render-alt-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-alt-small-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/windows-assets/render-assets.sh
+++ b/src/assets/gtk/windows-assets/render-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/windows-assets/render-assets.sh
+++ b/src/assets/gtk/windows-assets/render-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton"

--- a/src/assets/gtk/windows-assets/render-assets.sh
+++ b/src/assets/gtk/windows-assets/render-assets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -11,32 +13,32 @@ INDEX="assets.txt"
 
 ## Normal titlebutton
 
-mkdir -p $ASSETS_DIR
+mkdir -p "$ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
-if [ -f $ASSETS_DIR/$i$d.png ]; then
-    echo $ASSETS_DIR/$i$d.png exists.
+if [[ -f "$ASSETS_DIR/$i$d.png" ]]; then
+    echo "$ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i$d \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
+    echo "Rendering $ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $ASSETS_DIR/$i$d@2.png ]; then
-    echo $ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d@2.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d@2.png"
 fi
 
 done
@@ -44,32 +46,32 @@ done
 
 ## Normal nord titlebutton
 
-mkdir -p $NORD_ASSETS_DIR
+mkdir -p "$NORD_ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
-if [ -f $NORD_ASSETS_DIR/$i$d.png ]; then
-    echo $NORD_ASSETS_DIR/$i$d.png exists.
+if [[ -f "$NORD_ASSETS_DIR/$i$d.png" ]]; then
+    echo "$NORD_ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $NORD_ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i$d \
-              --export-id-only \
-              --export-png=$NORD_ASSETS_DIR/$i$d.png $NORD_SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $NORD_ASSETS_DIR/$i$d.png 
+    echo "Rendering $NORD_ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-id-only \
+                --export-filename="$NORD_ASSETS_DIR/$i$d.png" "$NORD_SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$NORD_ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $NORD_ASSETS_DIR/$i$d@2.png ]; then
-    echo $NORD_ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$NORD_ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$NORD_ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $NORD_ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$NORD_ASSETS_DIR/$i$d@2.png $NORD_SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $NORD_ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $NORD_ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$NORD_ASSETS_DIR/$i$d@2.png" "$NORD_SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$NORD_ASSETS_DIR/$i$d@2.png"
 fi
 
 done

--- a/src/assets/gtk/windows-assets/render-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-small-assets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
@@ -7,33 +9,33 @@ SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton-small"
 INDEX="assets.txt"
 
-mkdir -p $ASSETS_DIR
+mkdir -p "$ASSETS_DIR"
 
-for i in `cat $INDEX` ; do
-for d in '' '-dark' ; do
+for i in $(cat "$INDEX"); do
+for d in '' '-dark'; do
 
 ## small titlebutton
-if [ -f $ASSETS_DIR/$i$d.png ]; then
-    echo $ASSETS_DIR/$i$d.png exists.
+if [[ -f "$ASSETS_DIR/$i$d.png" ]]; then
+    echo "$ASSETS_DIR/$i$d.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d.png
-    $INKSCAPE --export-id=$i-small$d \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d.png 
+    echo "Rendering $ASSETS_DIR/$i$d.png"
+    "$INKSCAPE" --export-id="$i-small$d" \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d.png"
 fi
 
-if [ -f $ASSETS_DIR/$i$d@2.png ]; then
-    echo $ASSETS_DIR/$i$d@2.png exists.
+if [[ -f "$ASSETS_DIR/$i$d@2.png" ]]; then
+    echo "$ASSETS_DIR/$i$d@2.png exists."
 else
     echo
-    echo Rendering $ASSETS_DIR/$i$d@2.png
-    $INKSCAPE --export-id=$i-small$d \
-              --export-dpi=192 \
-              --export-id-only \
-              --export-png=$ASSETS_DIR/$i$d@2.png $SRC_FILE >/dev/null \
-    && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i$d@2.png 
+    echo "Rendering $ASSETS_DIR/$i$d@2.png"
+    "$INKSCAPE" --export-id="$i-small$d" \
+                --export-dpi=192 \
+                --export-id-only \
+                --export-filename="$ASSETS_DIR/$i$d@2.png" "$SRC_FILE" >/dev/null \
+    && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i$d@2.png"
 fi
 
 done

--- a/src/assets/gtk/windows-assets/render-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-small-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/gtk/windows-assets/render-small-assets.sh
+++ b/src/assets/gtk/windows-assets/render-small-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 SRC_FILE="windows-assets.svg"
 ASSETS_DIR="titlebutton-small"

--- a/src/assets/labwc/render-assets.sh
+++ b/src/assets/labwc/render-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/labwc/render-assets.sh
+++ b/src/assets/labwc/render-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 INDEX="assets.txt"
 

--- a/src/assets/labwc/render-assets.sh
+++ b/src/assets/labwc/render-assets.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
-OPTIPNG="$(command -v optipng)" || true
 
 INDEX="assets.txt"
 
-for i in `cat $INDEX`; do
+for i in $(cat "$INDEX"); do
   for color in '-Dark' '-Light'; do
     for theme in '' '-nord'; do
         ASSETS_DIR="assets${color}${theme}"
         SRC_FILE="assets${color}${theme}.svg"
 
-        mkdir -p $ASSETS_DIR
+        mkdir -p "$ASSETS_DIR"
 
           echo
-          echo Rendering $ASSETS_DIR/$i.svg
-          $INKSCAPE --export-id=$i \
-                    --export-id-only \
-                    --export-filename=$ASSETS_DIR/$i.svg $SRC_FILE >/dev/null
+          echo "Rendering $ASSETS_DIR/$i.svg"
+          "$INKSCAPE" --export-id="$i" \
+                      --export-id-only \
+                      --export-filename="$ASSETS_DIR/$i.svg" "$SRC_FILE" >/dev/null
 
     done
   done

--- a/src/assets/render-all-assets.sh
+++ b/src/assets/render-all-assets.sh
@@ -1,43 +1,33 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+RENDER_SVG="$(command -v rendersvg)" || true
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
-# check command availability
-has_command() {
-  command -v "$1" > /dev/null 2>&1
-}
-
-if ! has_command inkscape; then
-  echo inkscape and optipng needs to be installed to generate the assets.
-  if has_command zypper; then
-    sudo zypper in inkscape optipng
-  elif has_command apt; then
-    sudo apt install inkscape optipng
-  elif has_command dnf; then
-    sudo dnf install -y inkscape optipng
-  elif has_command yum; then
-    sudo yum install inkscape optipng
-  elif has_command pacman; then
-    sudo pacman -S --noconfirm inkscape optipng
-  fi
+if [[ -z "${INKSCAPE}" ]] && [[ -z "${RENDER_SVG}" ]]; then
+  echo "inkscape or rendersvg needs to be installed to generate the assets."
+  exit 1
 fi
 
-echo Rendering gtk-2.0 assets
-cd gtk-2.0 && ./render-assets.sh
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
-echo Rendering gtk-3.0 assets
-cd gtk-3.0 && ./render-thumbnails.sh
-cd gtk-3.0/common-assets && ./render-assets.sh
-cd gtk-3.0/windows-assets && ./render-assets.sh && ./render-alt-assets.sh
+echo "Rendering gtk-2.0 assets"
+(cd gtk-2.0 && ./render-assets.sh)
 
-echo Rendering cinnamon thumbnails
-cd cinnamon && ./render-thumbnails.sh
+echo "Rendering gtk-3.0 assets"
+(cd gtk-3.0 && ./render-thumbnails.sh)
+(cd gtk-3.0/common-assets && ./render-assets.sh)
+(cd gtk-3.0/windows-assets && ./render-assets.sh && ./render-alt-assets.sh)
 
-echo Rendering metacity-1 assets
-cd metacity-1 && ./render-assets.sh
+echo "Rendering cinnamon thumbnails"
+(cd cinnamon && ./render-thumbnails.sh)
 
-echo Rendering xfwm4 assets
-cd xfwm4 && ./render-assets.sh
+echo "Rendering metacity-1 assets"
+(cd metacity-1 && ./render-assets.sh)
+
+echo "Rendering xfwm4 assets"
+(cd xfwm4 && ./render-assets.sh)
 
 exit 0

--- a/src/assets/render-all-assets.sh
+++ b/src/assets/render-all-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/render-all-assets.sh
+++ b/src/assets/render-all-assets.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
-# check command avalibility
+# check command availability
 has_command() {
-  "$1" -v $1 > /dev/null 2>&1
+  command -v "$1" > /dev/null 2>&1
 }
 
 if ! has_command inkscape; then

--- a/src/assets/xfwm4/render-assets.sh
+++ b/src/assets/xfwm4/render-assets.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 INKSCAPE="/usr/bin/inkscape"
 OPTIPNG="/usr/bin/optipng"

--- a/src/assets/xfwm4/render-assets.sh
+++ b/src/assets/xfwm4/render-assets.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
 INDEX="assets.txt"
 
-for i in `cat $INDEX`; do
+for i in $(cat "$INDEX"); do
   for color in '-Dark' '-Light'; do
     for theme in '' '-nord'; do
       for screen in '' '-hdpi' '-xhdpi'; do
@@ -24,18 +26,18 @@ for i in `cat $INDEX`; do
               ;;
         esac
 
-        mkdir -p $ASSETS_DIR
+        mkdir -p "$ASSETS_DIR"
 
-        if [ -f $ASSETS_DIR/$i.png ]; then
-          echo $ASSETS_DIR/$i.png exists.
+        if [[ -f "$ASSETS_DIR/$i.png" ]]; then
+          echo "$ASSETS_DIR/$i.png exists."
         else
           echo
-          echo Rendering $ASSETS_DIR/$i.png
-          $INKSCAPE --export-id=$i \
-                    --export-id-only \
-                    --export-dpi=$DPI \
-                    --export-filename=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
-          && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
+          echo "Rendering $ASSETS_DIR/$i.png"
+          "$INKSCAPE" --export-id="$i" \
+                      --export-id-only \
+                      --export-dpi="$DPI" \
+                      --export-filename="$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null \
+          && "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i.png"
         fi
       done
     done

--- a/src/assets/xfwm4/render-assets.sh
+++ b/src/assets/xfwm4/render-assets.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-INKSCAPE="/usr/bin/inkscape"
-OPTIPNG="/usr/bin/optipng"
+INKSCAPE="$(command -v inkscape)" || true
+OPTIPNG="$(command -v optipng)" || true
 
 INDEX="assets.txt"
 

--- a/src/main/gtk-2.0/make-gtkrc.sh
+++ b/src/main/gtk-2.0/make-gtkrc.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 for color in '-light' '-dark'; do
 for theme in '' '-blue' '-purple' '-pink' '-red' '-orange' '-yellow' '-green' '-grey'; do

--- a/src/main/gtk-3.0/make_gresource_xml.sh
+++ b/src/main/gtk-3.0/make_gresource_xml.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 INDEX="../../assets/gtk/common-assets/assets.txt"
 SINDEX="../../assets/gtk/common-assets/sidebar-assets.txt"

--- a/src/main/gtk-4.0/make_gresource_xml.sh
+++ b/src/main/gtk-4.0/make_gresource_xml.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 INDEX="../../assets/gtk/common-assets/assets.txt"
 SINDEX="../../assets/gtk/common-assets/sidebar-assets.txt"

--- a/tweaks.sh
+++ b/tweaks.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # WARNING: Please make this shell not working-directory dependant, for example
 # instead of using 'ls blabla', use 'ls "${REPO_DIR}/blabla"'

--- a/wallpaper/install-gnome-backgrounds.sh
+++ b/wallpaper/install-gnome-backgrounds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 readonly ROOT_UID=0
 


### PR DESCRIPTION
## Summary

Shell script hygiene pass across the project. Each commit addresses one category of issues, keeping changes reviewable and bisectable. All changes are mechanical and behavior-preserving.

## Commits

| # | Commit | Files | What |
|---|--------|-------|------|
| 1 | `Standardize shebangs to #!/usr/bin/env bash` | 27 | Fix mixed `#! /usr/bin/env bash`, `#!/bin/bash`, `#! /bin/bash` |
| 2 | `Replace non-POSIX 'which' with 'command -v'` | 4 | `which` is not POSIX; use `command -v` instead |
| 3 | `Replace hardcoded /usr/bin/inkscape and /usr/bin/optipng` | 10 | Use `command -v` lookups for portability (NixOS, Flatpak, Snap) |
| 4 | `Add error handling and quoting to render scripts` | 10 | `set -euo pipefail`, quote vars, `[[ ]]`, subshell `cd` |
| 5 | `Fix undefined function calls in GDM make_gresource.sh` | 1 | Remove calls to `prepare_swupd`, `prepare_install_apt_packages`, `prepare_xbps` |
| 6 | `Update .gitignore with missing entries` | 1 | Add `release/`, `other/gdm/theme/*.css`, fix dash-to-dock path |

## Verification

```bash
# All shebangs are consistent
grep -rn '#!/' --include='*.sh' . | grep -v '#!/usr/bin/env bash' | grep -v '.git/'
# (should return nothing)

# No remaining 'which' usage
grep -rn 'which ' --include='*.sh' . | grep -v '.git/' | grep -v 'which component'
# (should return nothing)

# No remaining hardcoded /usr/bin paths in render scripts
grep -rn '/usr/bin/inkscape\|/usr/bin/optipng' --include='*.sh' src/assets/
# (should return nothing)
```